### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://supercoolsoftware.visualstudio.com/09828300-97b1-4f3b-a4d0-a8a691cee35c/b5ba604e-383b-4ca6-85a0-899fe4bc8356/_apis/work/boardbadge/d85a20e8-730d-4c8c-aa18-b4dc2c0a52c0)](https://supercoolsoftware.visualstudio.com/09828300-97b1-4f3b-a4d0-a8a691cee35c/_boards/board/t/b5ba604e-383b-4ca6-85a0-899fe4bc8356/Microsoft.RequirementCategory)
 # AngularPatientmanagerFrontendEval
 
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 17.0.0.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://supercoolsoftware.visualstudio.com/09828300-97b1-4f3b-a4d0-a8a691cee35c/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.